### PR TITLE
Comprobar creación de Usuario

### DIFF
--- a/decide/authentication/tests.py
+++ b/decide/authentication/tests.py
@@ -159,6 +159,8 @@ class RegisterGuiTests(TestCase):
         #The form returns the user to the form in case of a failure
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, template_name = 'register.html')
+        #Checking that the user hasn't been created
+        self.assertFalse(User.objects.filter(username=self.username).exists())
 
     #Testing a post request with no username given
     @override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')


### PR DESCRIPTION
Mejora

Ahora el test `register_form_bad_pass` en `authentication/tests.py` comprueba que NO se ha creado un usuario.

Incidencia relacionada: https://github.com/pabfrasan/decide/issues/98