### PR TITLE
Fix de Editar Usuario

### DIFF
--- a/decide/authentication/templates/edit_user_profile.html
+++ b/decide/authentication/templates/edit_user_profile.html
@@ -29,7 +29,7 @@
             <input name="email" class="form-control" placeholder="" type="text" value="{{email}}">
         </div> <!-- form-group// -->  
         <div class="col-md-6 text-right">
-            <button  href="../updateprofile" type="submit" class="float-right btn btn-outline-primary">Actualizar usuario</a>
+            <button  href="../profile/{{username}}"  type="submit" class="float-right btn btn-outline-primary">Actualizar usuario</button>
         </div>                                                                                                    
     </form>
     </article>

--- a/decide/authentication/templates/edit_user_profile.html
+++ b/decide/authentication/templates/edit_user_profile.html
@@ -31,7 +31,7 @@
         </div> <!-- form-group// -->   
         <div class="form-group">
             <h6>Email:</h6>
-            <input name="email" class="form-control" placeholder="" type="text" value="{{email}}">
+            <input readonly name="email" class="form-control" placeholder="" type="text" value="{{email}}">
         </div> <!-- form-group// -->  
         <div>
             <button  href="../profile/{{username}}"  type="submit" class="float-right btn btn-outline-primary">Actualizar usuario</button>

--- a/decide/authentication/templates/edit_user_profile.html
+++ b/decide/authentication/templates/edit_user_profile.html
@@ -28,9 +28,16 @@
             <h6>Email:</h6>
             <input name="email" class="form-control" placeholder="" type="text" value="{{email}}">
         </div> <!-- form-group// -->  
-        <div class="col-md-6 text-right">
+        <div>
             <button  href="../profile/{{username}}"  type="submit" class="float-right btn btn-outline-primary">Actualizar usuario</button>
-        </div>                                                                                                    
+        </div>       
+        <br><br><br>
+        <p>
+         <a href="{% url 'social:begin' 'twitter' %}" class="btn btn-block btn-outline-info"> <i class="fab fa-twitter"></i> Enlazar a Twitter</a>
+        </p>  
+        <p>
+         <a href="{% url 'social:begin' 'facebook' %}" class="btn btn-block btn-outline-primary"> <i class="fab fa-facebook-f"></i> Enlazar a facebook</a>
+        </p>  
     </form>
     </article>
     </div> <!-- card.// -->

--- a/decide/authentication/templates/edit_user_profile.html
+++ b/decide/authentication/templates/edit_user_profile.html
@@ -11,7 +11,12 @@
     <article class="card-body">	
         <hr>
         <form method="POST">
-			{% csrf_token %}
+            {% csrf_token %}
+            {% if messages %}
+            {% for message in messages %}
+        <div class="card-title mb-4 mt-1 text-center">{{ message|safe }}</div>
+            {% endfor %}
+            {% endif %}
         <div class="form-group">
             <h6>Nombre de usuario:</h6>
             <input name="username" class="form-control" placeholder="" type="text" value="{{username}}">

--- a/decide/authentication/templates/user_profile.html
+++ b/decide/authentication/templates/user_profile.html
@@ -27,7 +27,10 @@
         <div class="form-group">
             <h6>Email:</h6>
             <input readonly name="email" class="form-control" placeholder="" type="text" value="{{email}}">
-        </div> <!-- form-group// -->                                                                                                
+        </div> <!-- form-group// -->   
+        <div class="col-md-6 text-right">
+            <a href="../editprofile/{{username}}" class="float-right btn btn-outline-primary">Editar Perfil</a>
+        </div>                                                                                                
     </form>
     </article>
     </div> <!-- card.// -->

--- a/decide/authentication/templates/user_profile.html
+++ b/decide/authentication/templates/user_profile.html
@@ -28,7 +28,7 @@
             <h6>Email:</h6>
             <input readonly name="email" class="form-control" placeholder="" type="text" value="{{email}}">
         </div> <!-- form-group// -->   
-        <div class="col-md-6 text-right">
+        <div>
             <a href="../editprofile/{{username}}" class="float-right btn btn-outline-primary">Editar Perfil</a>
         </div>                                                                                                
     </form>

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -198,7 +198,6 @@ class EditUserProfile:
          elif request.POST.get('username') == '':         
              messages.error(request, 'El nombre de usuario de puede estar vacío.')
          elif User.objects.get(username=request.POST.get('username')).DoesNotExist:
-             print("aaaa")
              messages.error(request, 'El nombre de usuario ya está en uso.')
         else:
             form = UpdateProfile()

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -190,8 +190,11 @@ class EditUserProfile:
          form.actual_user = request.user
          if form.is_valid():
              form.save()
-             username = user.username
-             return render(request, 'user_profile.html', context={'username': username})
+             username = form.actual_user.username
+             first_name = form.actual_user.first_name
+             last_name = form.actual_user.last_name
+             email = form.actual_user.email
+             return render(request, 'user_profile.html', context={'username': username,'first_name': first_name, 'last_name': last_name, 'email': email})
         else:
             form = UpdateProfile()
         return render(request, 'edit_user_profile.html', context={'username': username,'first_name': first_name, 'last_name': last_name, 'email': email})

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -151,6 +151,10 @@ class UserProfile:
         context = {
             "user": user
         }
+        selfusername = request.user.username
+        if not username == selfusername:
+            return HttpResponse('You are not authorized to see this page.')
+
         return render(request, 'user_profile.html', context={'username': username,'first_name': first_name, 'last_name': last_name, 'email': email})
 
 class ProfileView(APIView):
@@ -159,11 +163,10 @@ class ProfileView(APIView):
         tk = get_object_or_404(Token, key=key)
         if not tk.user.is_superuser:
             return Response({}, status=HTTP_401_UNAUTHORIZED)
-
+        
         username = user.profile.username
         if not username:
             return Response({}, status=HTTP_400_BAD_REQUEST)
-
 
         return Response(request, 'user_profile.html', context)
 
@@ -179,6 +182,9 @@ class EditUserProfile:
         context = {
             "user": user
         }
+        selfusername = request.user.username
+        if not username == selfusername:
+            return HttpResponse('You are not authorized to see this page.')
         if request.method == 'POST':
          form = UpdateProfile(request.POST, instance=request.user)
          form.actual_user = request.user
@@ -200,6 +206,5 @@ class EditProfileView(APIView):
         username = user.profile.username
         if not username:
             return Response({}, status=HTTP_400_BAD_REQUEST)
-
 
         return Response(request, 'user_profile.html', context)

--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -22,6 +22,7 @@ from django.template.loader import render_to_string
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.contrib import messages
 
 from .forms import RegisterForm
 from django.contrib.auth import logout, login, authenticate
@@ -178,7 +179,6 @@ class EditUserProfile:
         first_name = user.first_name
         last_name = user.last_name
         email = user.email
-        password = user.password
         context = {
             "user": user
         }
@@ -189,12 +189,17 @@ class EditUserProfile:
          form = UpdateProfile(request.POST, instance=request.user)
          form.actual_user = request.user
          if form.is_valid():
-             form.save()
-             username = form.actual_user.username
-             first_name = form.actual_user.first_name
-             last_name = form.actual_user.last_name
-             email = form.actual_user.email
-             return render(request, 'user_profile.html', context={'username': username,'first_name': first_name, 'last_name': last_name, 'email': email})
+                form.save()
+                username = form.actual_user.username
+                first_name = form.actual_user.first_name
+                last_name = form.actual_user.last_name
+                email = form.actual_user.email
+                return render(request, 'user_profile.html', context={'username': username,'first_name': first_name, 'last_name': last_name, 'email': email}) 
+         elif request.POST.get('username') == '':         
+             messages.error(request, 'El nombre de usuario de puede estar vacío.')
+         elif User.objects.get(username=request.POST.get('username')).DoesNotExist:
+             print("aaaa")
+             messages.error(request, 'El nombre de usuario ya está en uso.')
         else:
             form = UpdateProfile()
         return render(request, 'edit_user_profile.html', context={'username': username,'first_name': first_name, 'last_name': last_name, 'email': email})


### PR DESCRIPTION
Fix

Se han implementado diversos fix a la funcionalidad de editar los datos de usuario. Añadido un botón para editar el perfil sin necesidad de tener que acceder por link. Sólo el propio usuario puede ver y editar sus datos personales de usuario. Tras editar el perfil, el usuario es redirigido a sus datos personales actualizados. Se ha posibilitado el enlace de las redes sociales al propio usuario. Se han añadido mensajes de error al introducir un nombre de usuario vacío o no disponible. El email con el que se verificó la cuenta ya no puede ser modificado.

En referencia a las incidencias I-007-B, I-008-B, I-009-B, I-012-B, I-015-B.