### PR TITLE
API Keys escondidas y cambiadas.

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -70,14 +70,14 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 #Social Login Keys
-
+import environ
 #Facebook App Keys
-SOCIAL_AUTH_FACEBOOK_KEY = '1611054769087460'
-SOCIAL_AUTH_FACEBOOK_SECRET = 'e5a981424b175589a87110c712dc3584'
+SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('SOCIAL_AUTH_FACEBOOK_KEY')
+SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET')
 
 #Twitter App keys
-SOCIAL_AUTH_TWITTER_KEY = 'YeLc8PNE10orRRnAMINCwyPWG'
-SOCIAL_AUTH_TWITTER_SECRET = 'K0I5W9xa2Btcv2xxO1IpacNXlTioplgeXVUlBG3XMbHwpei76B'
+SOCIAL_AUTH_TWITTER_KEY = os.environ.get('SOCIAL_AUTH_TWITTER_KEY')
+SOCIAL_AUTH_TWITTER_SECRET = os.environ.get('SOCIAL_AUTH_TWITTER_SECRET')
 
 #Email Auth Backend (For testing and debugging purposes, not yet ready for production)
 #If emails doesn't show up in the command prompt when performing an email dependant operation (Such as email verification)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ jsonnet==0.12.1
 django-heroku
 gunicorn
 social-auth-app-django
+python-environ


### PR DESCRIPTION
Se han escondido las API KEYS y se han añadido al requirements.txt las dependencias necesarias para cargarlas.
Las API Keys han sido cambiadas para evitar un problema de seguridad, todo el mundo debe añadirlas a su fichero local_settings.py cuando se trabaje en local.